### PR TITLE
Feature/implement opportunity status validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royal-voluntary-service/validation",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Royal Voluntary Service Validation Package",
   "private": false,
   "publishConfig": {

--- a/src/validations/opportunity/opportunityStatus.ts
+++ b/src/validations/opportunity/opportunityStatus.ts
@@ -1,5 +1,28 @@
+import { RecordState } from "@prisma/client";
+import { getAllValidCase, toHumanString, toSentenceCase } from "../../utils/string";
 
-// Placeholder function for testing type output
-export const validateOpportunityStatus = (status: string): boolean => {
-    return ['type1', 'type2', 'type3'].includes(status);
+const DEFAULT_RECORD_STATE = RecordState.INACTIVE;
+
+export const POSSIBLE_RECORD_STATES = Object.values(RecordState).map(type => toSentenceCase(toHumanString(type)));
+
+export const validateOpportunityStatus = (type: string): boolean => Object.values(RecordState).map((val) => getAllValidCase(val)).flat().includes(type)
+
+
+export const validateOpportunityStatusForCSV = (type?: string | number | null) => {
+    function toReturn() {
+        return {
+            level: "healing",
+            message: "Opportunity Status should be one of: " + POSSIBLE_RECORD_STATES.join(', '),
+            newValue: toSentenceCase(toHumanString(DEFAULT_RECORD_STATE))
+        }
+    }
+    if (!type || typeof type === "number") {
+        return toReturn()
+    }
+    const isValidCase = validateOpportunityStatus(type)
+    if (!isValidCase) {
+        return toReturn()
+    }
+    return null
 };
+

--- a/tests/unit/validations/opportunity/opportunityStatus.spec.ts
+++ b/tests/unit/validations/opportunity/opportunityStatus.spec.ts
@@ -1,0 +1,74 @@
+
+import { validateOpportunityStatus, validateOpportunityStatusForCSV } from "../../../../src/validations/opportunity/opportunityStatus";
+
+
+describe("validateOpportunityStatus", () => {
+  it("should return true for valid opportunity status", () => {
+    const result = validateOpportunityStatus("ACTIVE");
+    expect(result).toBe(true);
+  });
+
+  it("should return false for invalid opportunity status", () => {
+    const result = validateOpportunityStatus("SOMETHING_ELSE");
+    expect(result).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    const result = validateOpportunityStatus("");
+    expect(result).toBe(false);
+  });
+});
+
+describe("validateOpportunityStatusForCSV", () => {
+  it("should return a default error message when status is undefined", () => {
+    const result = validateOpportunityStatusForCSV();
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity Status should be one of: Active, Inactive",
+      newValue: "Inactive",
+    });
+  });
+
+  it("should return a default error message when status is a number", () => {
+    const result = validateOpportunityStatusForCSV(123);
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity Status should be one of: Active, Inactive",
+      newValue: "Inactive",
+    });
+  });
+
+  it("should return a default error message when status is invalid", () => {
+    const result = validateOpportunityStatusForCSV("Invalid Type");
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity Status should be one of: Active, Inactive",
+      newValue: "Inactive",
+    });
+  });
+
+  it("should return null when status is valid", () => {
+    const resultOne = validateOpportunityStatusForCSV("ACTIVE");
+    const resultTwo = validateOpportunityStatusForCSV("Active");
+    const resultThree = validateOpportunityStatusForCSV("active");
+    const resultFour = validateOpportunityStatusForCSV("INACTIVE");
+    const resultFive = validateOpportunityStatusForCSV("Inactive");
+    const resultSix = validateOpportunityStatusForCSV("inactive");
+    expect(resultOne).toBeNull();
+    expect(resultTwo).toBeNull();
+    expect(resultThree).toBeNull();
+    expect(resultFour).toBeNull();
+    expect(resultFive).toBeNull();
+    expect(resultSix).toBeNull();
+  });
+  
+
+  it("should return the correct error message when status is invalid", () => {
+    const result = validateOpportunityStatusForCSV("Non-existent Type");
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity Status should be one of: Active, Inactive",
+      newValue: "Inactive",
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes updates to the validation logic for opportunity statuses and adds corresponding unit tests. Additionally, it includes a minor version bump in the `package.json` file.

Changes to validation logic:

* [`src/validations/opportunity/opportunityStatus.ts`](diffhunk://#diff-920a9c2dc15e22c5689aa4d354f3e3f48528be8351e23bcf48a9b2a1929cf4e0R1-R28): Introduced `RecordState` from `@prisma/client`, updated `validateOpportunityStatus` to use `RecordState` values, and added a new function `validateOpportunityStatusForCSV` to validate opportunity statuses specifically for CSV inputs.

Unit tests:

* [`tests/unit/validations/opportunity/opportunityStatus.spec.ts`](diffhunk://#diff-dac0df588572a44272f5940ebcc2ff3f6f603361f1876eca657100c9e00b9f8eR1-R74): Added unit tests for `validateOpportunityStatus` and `validateOpportunityStatusForCSV` functions to ensure they handle various input scenarios correctly.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.4` to `0.0.5`.