### PR TITLE
Feature/implement opportunity commitment validation

### DIFF
--- a/src/validations/opportunity/opportunityCause.ts
+++ b/src/validations/opportunity/opportunityCause.ts
@@ -38,7 +38,7 @@ export const validateOpportunityCause = async (cause: string): Promise<boolean> 
 export const validateOpportunityCauseForCSV = async (type?: string | number | null): Promise<null | CsvValidatorResponse> => {
     await syncLatestCauses();
 
-    function toReturn(): CsvValidatorResponse {
+    const toReturn = (): CsvValidatorResponse => {
         return getCsvValidationResponse(
             "healing",
             "Opportunity Cause should be one of: " + lastCauses.join(', '),

--- a/src/validations/opportunity/opportunityCommitment.ts
+++ b/src/validations/opportunity/opportunityCommitment.ts
@@ -11,7 +11,7 @@ export const validateOpportunityCommitment = (type: string): boolean => Object.v
 
 
 export const validateOpportunityCommitmentForCSV = (type?: string | number | null): null | CsvValidatorResponse => {
-    function toReturn(): CsvValidatorResponse {
+    const toReturn = (): CsvValidatorResponse => {
         return getCsvValidationResponse(
             "healing",
             "Opportunity commitment should be one of: " + POSSIBLE_OPPORTUNITY_COMMITMENTS.join(', '), // error message

--- a/src/validations/opportunity/opportunityCommitment.ts
+++ b/src/validations/opportunity/opportunityCommitment.ts
@@ -1,4 +1,29 @@
-// Placeholder function for testing type output
-export const validateOpportunityCommitment = (commitment: string): boolean => {
-    return ['full time', 'part time'].includes(commitment);
+import { OpportunityCommitment } from "@prisma/client";
+import { getAllValidCase, toHumanString, toSentenceCase } from "../../utils/string";
+import type { CsvValidatorResponse } from "../../types/csvValidation";
+import { getCsvValidationResponse } from "../../utils/csvValidation";
+
+const DEFAULT_OPPORTUNITY_COMMITMENT = OpportunityCommitment.REGULAR;
+
+export const POSSIBLE_OPPORTUNITY_COMMITMENTS = Object.values(OpportunityCommitment).map(type => toSentenceCase(toHumanString(type)));
+
+export const validateOpportunityCommitment = (type: string): boolean => Object.values(OpportunityCommitment).map((val) => getAllValidCase(val)).flat().includes(type)
+
+
+export const validateOpportunityCommitmentForCSV = (type?: string | number | null): null | CsvValidatorResponse => {
+    function toReturn(): CsvValidatorResponse {
+        return getCsvValidationResponse(
+            "healing",
+            "Opportunity commitment should be one of: " + POSSIBLE_OPPORTUNITY_COMMITMENTS.join(', '), // error message
+            toSentenceCase(toHumanString(DEFAULT_OPPORTUNITY_COMMITMENT))
+        )
+    }
+    if (!type || typeof type === "number") {
+        return toReturn()
+    }
+    const isValidCase = validateOpportunityCommitment(type)
+    if (!isValidCase) {
+        return toReturn()
+    }
+    return null
 };

--- a/src/validations/opportunity/opportunityStatus.ts
+++ b/src/validations/opportunity/opportunityStatus.ts
@@ -11,7 +11,7 @@ export const validateOpportunityStatus = (type: string): boolean => Object.value
 
 
 export const validateOpportunityStatusForCSV = (type?: string | number | null): null | CsvValidatorResponse => {
-    function toReturn(): CsvValidatorResponse {
+    const toReturn = (): CsvValidatorResponse => {
         return getCsvValidationResponse(
             "healing",
             "Opportunity Status should be one of: " + POSSIBLE_RECORD_STATES.join(', '),

--- a/src/validations/opportunity/opportunityType.ts
+++ b/src/validations/opportunity/opportunityType.ts
@@ -11,7 +11,7 @@ export const validateOpportunityType = (type: string): boolean => Object.values(
 
 
 export const validateOpportunityTypeForCSV = (type?: string | number | null): null | CsvValidatorResponse => {
-    function toReturn(): CsvValidatorResponse {
+    const toReturn = (): CsvValidatorResponse => {
         return getCsvValidationResponse(
             "healing",
             "Opportunity type should be one of: " + POSSIBLE_OPPORTUNITY_TYPES.join(', '), // error message

--- a/src/validations/opportunity/validateOpportunityCsvRow.ts
+++ b/src/validations/opportunity/validateOpportunityCsvRow.ts
@@ -1,5 +1,6 @@
 import type { CsvValidatorImportValue, CsvValidatorResponse } from "../../types/csvValidation";
 import { validateOpportunityCauseForCSV } from "./opportunityCause";
+import { validateOpportunityCommitmentForCSV } from "./opportunityCommitment";
 import { validateOpportunityStatusForCSV } from "./opportunityStatus";
 import { validateOpportunityTypeForCSV } from "./opportunityType";
 
@@ -32,7 +33,7 @@ export const validateCsvRowDataAndReturnErrors = async (
     const opportunityTypeValidator = validateOpportunityTypeForCSV(opportunityType)
     const opportunityStatusValidator = validateOpportunityStatusForCSV(status)
     const opportunityCauseValidator = await validateOpportunityCauseForCSV(cause)
-    // const opportunityCommitmentValidator = validateOpportunityCommitmentForCSV(commitment)
+    const opportunityCommitmentValidator = validateOpportunityCommitmentForCSV(commitment)
     if (opportunityTypeValidator !== null) {
         data.opportunityType = [opportunityTypeValidator]
     }
@@ -42,9 +43,9 @@ export const validateCsvRowDataAndReturnErrors = async (
     if (opportunityCauseValidator !== null) {
         data.cause = [opportunityCauseValidator]
     }
-    // if (opportunityCommitmentValidator !== null) {
-    //     data.commitment = [opportunityCommitmentValidator]
-    // }
+    if (opportunityCommitmentValidator !== null) {
+        data.commitment = [opportunityCommitmentValidator]
+    }
     if (Object.keys(data).length !== 0) {
         return data;
     }

--- a/tests/unit/validations/opportunity/opportunityCommitment.spec.ts
+++ b/tests/unit/validations/opportunity/opportunityCommitment.spec.ts
@@ -1,13 +1,79 @@
-import { validateOpportunityCommitment } from '../../../../src/validations/opportunity/opportunityCommitment';
+import { validateOpportunityCommitment, validateOpportunityCommitmentForCSV } from "../../../../src/validations/opportunity/opportunityCommitment";
 
-describe('validateOpportunityCommitment', () => {
-    it('should return true for valid commitments', () => {
-        expect(validateOpportunityCommitment('full time')).toBe(true);
-        expect(validateOpportunityCommitment('part time')).toBe(true);
-    });
+// Remove the mocks for the utility functions
+// jest.mock("../../../../src/utils/string", () => ({
+//   getAllValidCase: jest.fn(),
+//   toHumanString: jest.fn(),
+//   toSentenceCase: jest.fn(),
+// }));
 
-    it('should return false for invalid commitments', () => {
-        expect(validateOpportunityCommitment('freelance')).toBe(false);
-        expect(validateOpportunityCommitment('')).toBe(false);
+describe("validateOpportunityCommitment", () => {
+  it("should return true for valid opportunity commitments", () => {
+    const result = validateOpportunityCommitment("Flexible");
+    expect(result).toBe(true);
+  });
+
+  it("should return false for invalid opportunity commitments", () => {
+    const result = validateOpportunityCommitment("Online");
+    expect(result).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    const result = validateOpportunityCommitment("");
+    expect(result).toBe(false);
+  });
+});
+
+describe("validateOpportunityCommitmentForCSV", () => {
+  it("should return a default error message when type is undefined", () => {
+    const result = validateOpportunityCommitmentForCSV();
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity commitment should be one of: Flexible, Regular",
+      newValue: "Regular",
     });
+  });
+
+  it("should return a default error message when type is a number", () => {
+    const result = validateOpportunityCommitmentForCSV(123);
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity commitment should be one of: Flexible, Regular",
+      newValue: "Regular",
+    });
+  });
+
+  it("should return a default error message when type is invalid", () => {
+    const result = validateOpportunityCommitmentForCSV("Invalid Type");
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity commitment should be one of: Flexible, Regular",
+      newValue: "Regular",
+    });
+  });
+
+  it("should return null when type is valid", () => {
+    const resultOne = validateOpportunityCommitmentForCSV("Regular");
+    const resultTwo = validateOpportunityCommitmentForCSV("regular");
+    const resultThree = validateOpportunityCommitmentForCSV("REGULAR");
+    const resultFour = validateOpportunityCommitmentForCSV("Flexible");
+    const resultFive = validateOpportunityCommitmentForCSV("flexible");
+    const resultSix = validateOpportunityCommitmentForCSV("FLEXIBLE");
+    expect(resultOne).toBeNull();
+    expect(resultTwo).toBeNull();
+    expect(resultThree).toBeNull();
+    expect(resultFour).toBeNull();
+    expect(resultFive).toBeNull();
+    expect(resultSix).toBeNull();
+  });
+  
+
+  it("should return the correct error message when type is invalid", () => {
+    const result = validateOpportunityCommitmentForCSV("Non-existent Type");
+    expect(result).toEqual({
+      level: "healing",
+      message: "Opportunity commitment should be one of: Flexible, Regular",
+      newValue: "Regular",
+    });
+  });
 });

--- a/tests/unit/validations/opportunity/validateOpportunityCsvRow.spec.ts
+++ b/tests/unit/validations/opportunity/validateOpportunityCsvRow.spec.ts
@@ -20,7 +20,7 @@ describe('validateDataAndReturnErrors', () => {
         ]);
         const result = await validateCsvRowDataAndReturnErrors(
             "In Person" as CsvValidatorImportValue,
-            "COMMITMENT" as CsvValidatorImportValue,
+            "Flexible" as CsvValidatorImportValue,
             "Animal Welfare" as CsvValidatorImportValue,
             "Active" as CsvValidatorImportValue
         );
@@ -34,7 +34,7 @@ describe('validateDataAndReturnErrors', () => {
         ]);
         const result = await validateCsvRowDataAndReturnErrors(
             "Something Else" as CsvValidatorImportValue,
-            "COMMITMENT" as CsvValidatorImportValue,
+            "Flexible" as CsvValidatorImportValue,
             "Animal Welfare" as CsvValidatorImportValue,
             "Active" as CsvValidatorImportValue
         );
@@ -48,7 +48,7 @@ describe('validateDataAndReturnErrors', () => {
         ]);
         const result = await validateCsvRowDataAndReturnErrors(
             "In Person" as CsvValidatorImportValue,
-            "COMMITMENT" as CsvValidatorImportValue,
+            "Regular" as CsvValidatorImportValue,
             "Animal Welfare" as CsvValidatorImportValue,
             "None" as CsvValidatorImportValue
         );
@@ -62,12 +62,24 @@ describe('validateDataAndReturnErrors', () => {
         ]);
         const result = await validateCsvRowDataAndReturnErrors(
             "In Person" as CsvValidatorImportValue,
-            "COMMITMENT" as CsvValidatorImportValue,
+            "Flexible" as CsvValidatorImportValue,
             "Not A Cause" as CsvValidatorImportValue,
             "Active" as CsvValidatorImportValue
         );
         expect(result).toHaveProperty('cause');
     });
 
-    // Add more tests as needed
+    it('should return errors for invalid opportunity commitment', async () => {
+        (prisma.cause.findMany as jest.Mock).mockResolvedValue([
+            { causeName: 'Animal Welfare' },
+            { causeName: 'Human Aid' }
+        ]);
+        const result = await validateCsvRowDataAndReturnErrors(
+            "In Person" as CsvValidatorImportValue,
+            "Never" as CsvValidatorImportValue,
+            "Animal Welfare" as CsvValidatorImportValue,
+            "Active" as CsvValidatorImportValue
+        );
+        expect(result).toHaveProperty('commitment');
+    });
 });


### PR DESCRIPTION
This pull request introduces significant changes to the validation logic for opportunities and integrates the Prisma ORM for database interactions. The most important changes include updating the validation functions to use data from the database, modifying the workflow configuration, and updating the unit tests accordingly.

### Integration of Prisma ORM:

* [`src/validations/opportunity/opportunityCommitment.ts`](diffhunk://#diff-382f412c25bf85fee778a01b91ab76ac19753a98a271a84c63c5e76ee4e8e0eaL1-R28): Updated `validateOpportunityCommitment` to use database values and added `validateOpportunityCommitmentForCSV`.


### Unit Tests Updates:
* [`tests/unit/validations/opportunity/opportunityCommitment.spec.ts`](diffhunk://#diff-a2686787d4eee71d0cd3309719288ada94c82d9509c37ac3634324d7c22fa671L1-R77): Added tests for `validateOpportunityCommitment` and `validateOpportunityCommitmentForCSV`.
* [`tests/unit/validations/opportunity/validateOpportunityCsvRow.spec.ts`](diffhunk://#diff-7be1bc7f7c8f8e8b3073741b91e01172cfd46528413f99abe9c32c3e51f1e038R1-R84): Mocked Prisma client and updated tests for `validateCsvRowDataAndReturnErrors`.